### PR TITLE
Add dotnet matrix build workflow

### DIFF
--- a/.github/workflows/dotnet-matrix-build.yml
+++ b/.github/workflows/dotnet-matrix-build.yml
@@ -1,0 +1,37 @@
+name: dotnet matrix build
+
+on:
+  pull_request:   
+    paths:
+    - src/**
+
+env:
+  DOTNET_VERSION: '8.0.x' # The .NET SDK version to use
+
+jobs:
+  build:
+
+    name: build-${{matrix.path}}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        path: ["./src/ApiGateways/YarpApiGateway/YarpApiGateway.csproj",
+               "./src/BuildingBlocks/BuildingBlocks/BuildingBlocks.csproj",
+               "./src/BuildingBlocks/BuildingBlocks.Messaging/BuildingBlocks.Messaging.csproj",
+               "./src/Services/Basket/Basket.API/Basket.API.csproj",
+               "./src/Services/Catalog/Catalog.API/Catalog.API.csproj",
+               "./src/Services/Discount/Discount.Grpc/Discount.Grpc.csproj",
+               "./src/Services/Ordering/Ordering.API/Ordering.API.csproj"]
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: ${{ env.DOTNET_VERSION }}
+
+    - name: Install dependencies
+      run: dotnet restore ${{ matrix.path }}
+      
+    - name: Build
+      run: dotnet build ${{ matrix.path }}  --configuration Release --no-restore


### PR DESCRIPTION
This PR adds a new GitHub Actions workflow to build multiple .NET projects using a matrix strategy. The workflow is triggered on pull requests that modify files under src/**.